### PR TITLE
Catch errors in glm(), e.g. from bootstrap samples that have no variation in a factor

### DIFF
--- a/R/clusbootglm.R
+++ b/R/clusbootglm.R
@@ -64,7 +64,8 @@ clusbootglm <- function(model, data, clusterid, family=gaussian, B=5000, confint
         j <- f[,i]
         obs <- unlist(Obsno[j])
         bootcoef <- tryCatch(coef(glm(model, family = family, data = data[obs,])), 
-                             warning=function(x) rep(as.numeric(NA),p))
+                             warning=function(x) rep(as.numeric(NA),p),
+                             error=function(x) rep(as.numeric(NA), p))
         coefs[i,which(names(res.or$coef) %in% names(bootcoef))] <- bootcoef
       }
     }

--- a/R/clusbootglm_internals.R
+++ b/R/clusbootglm_internals.R
@@ -3,7 +3,8 @@ clusbootglm_sample_glm <-function(f, i, Obsno, model, family, data, p, res.or){
   obs <- unlist(Obsno[j])
   coef <- rep(NA,p) #added
   bootcoef <- tryCatch(coef(glm(model, family = family, data = data[obs,])),
-                      warning=function(x) rep(as.numeric(NA),p))
+                      warning=function(x) rep(as.numeric(NA),p),
+                      error=function(x) rep(as.numeric(NA),p))
   ifelse(length(bootcoef)==p, coef <- as.vector(bootcoef), coef[which(names(res.or$coef) %in% names(bootcoef))] <- bootcoef)
   return(coef)
 }


### PR DESCRIPTION
This StackOverflow post:  https://stackoverflow.com/q/78945361 gives an example that fails with the error:
```
Error in `contrasts<-`(`*tmp*`, value = contr.funs[1 + isOF[nn]]) : 
  contrasts can be applied only to factors with 2 or more levels
```
The problem is that it has factors as covariates, and some of the bootstrap samples have no variation in the factor levels.  `glm()` doesn't return warnings in this case, it returns errors, so the whole process dies.

The suggested changes just handle errors the same way warnings were being handled.